### PR TITLE
Restore PHP 7 compatibility for GD image handling

### DIFF
--- a/lib/filters/filter.crop.php
+++ b/lib/filters/filter.crop.php
@@ -45,7 +45,9 @@ Class FilterCrop extends ImageFilter
 
         imagecopyresampled($tmp, $res, $src_x, $src_y, $dst_x, $dst_y, $image_width, $image_height, $image_width, $image_height);
 
-        if ($res instanceof GdImage) {
+        if (class_exists('GdImage') && $res instanceof GdImage) {
+            unset($res);
+        } elseif (is_resource($res)) {
             imagedestroy($res);
         }
 

--- a/lib/filters/filter.resize.php
+++ b/lib/filters/filter.resize.php
@@ -30,7 +30,9 @@ Class FilterResize extends ImageFilter
 
         imagecopyresampled($dst, $res, 0, 0, 0, 0, $dst_w, $dst_h, Image::width($res), Image::height($res));
 
-        if ($res instanceof GdImage) {
+        if (class_exists('GdImage') && $res instanceof GdImage) {
+            unset($res);
+        } elseif (is_resource($res)) {
             imagedestroy($res);
         }
 


### PR DESCRIPTION
- Added support for both resource (PHP < 8) and GdImage object (PHP >= 8)
- Restored compatibility for image creation, filters, and cleanup routines
- Added conditional `unset()`/`imagedestroy()` logic for PHP 7/8 interoperability
- The function `imagedestroy()` has been DEPRECATED as of PHP 8.5.0