### PR TITLE
Fix PNG image quality handling

### DIFF
--- a/lib/class.image.php
+++ b/lib/class.image.php
@@ -493,7 +493,9 @@ Class Image
                 return imagegif($this->_resource, $dest);
                 break;
             case IMAGETYPE_PNG:
-                return imagepng($this->_resource, $dest, round(9 * ($quality * 0.01)));
+                // PNG compression is lossless.
+                // Fixed to 9 (highest compression) for smallest file size.
+                return imagepng($this->_resource, $dest, 9);
                 break;
             case IMAGETYPE_WEBP:
                 return imagewebp($this->_resource, $dest, $quality);


### PR DESCRIPTION
For PNG images, the "quality" parameter represents a compression level (0–9).

Lossy quality (JPG, WebP, AVIF) is not equivalent to or convertible with lossless compression (PNG).

A fixed compression level of 9 is now used for PNG images to ensure consistent, lossless output with optimal file size.